### PR TITLE
Added mocks library to libr for external use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ new libr we just changed.
 	*modified:   libr (modified content)*  
 5) Now lets update the super-project to point to the new libr we just changed. It's just a normal git workflow but with an extra little spice. 
 See the explanation in the gotcha section below.  
-**git commit libr**  
+**git add libr**  
+**git commit (whatever)**    
 **git push --recurse-submodules=on-demand**  
 
 That's it!


### PR DESCRIPTION
A C exe with mocking cannot use both the mock and the real function in the at the same time therefore:

Separated memory test into it's own exe.
Separated list tests into a common exe.

Fix crash due to use of malloc in mock. Wrapped malloc and free in malloc_w and free_w functions.

Updated libr version in romi-rover-build-and-test