### PR TITLE
add range

### DIFF
--- a/romi-rover/grbl/grbl.c
+++ b/romi-rover/grbl/grbl.c
@@ -24,12 +24,19 @@
 #include <r.h>
 #include "grbl.h"
 
-static int initialized = 0;
-static char *device = NULL;
-static mutex_t *mutex = NULL;
-static serial_t *serial = NULL;
+#define XAXIS 0
+#define YAXIS 1
+#define ZAXIS 2
+#define MIN 0
+#define MAX 1
+
+static int _initialized = 0;
+static char *_device = NULL;
+static mutex_t *_mutex = NULL;
+static serial_t *_serial = NULL;
 //static int serial_errors = 0;
-static membuf_t *reply = NULL;
+static membuf_t *_reply = NULL;
+static double _range[3][2] = {{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}};
 
 static void broadcast_log(void *userdata, const char* s)
 {
@@ -42,26 +49,26 @@ static void broadcast_log(void *userdata, const char* s)
 static int open_serial(const char *dev)
 {
         r_info("Trying to open the serial connection on %s.", dev);
-	
-        mutex_lock(mutex);        
-        serial = new_serial(dev, 115200, 1);
-        mutex_unlock(mutex);        
-	
-        if (serial == NULL)
+
+        mutex_lock(_mutex);
+        _serial = new_serial(dev, 115200, 1);
+        mutex_unlock(_mutex);
+
+        if (_serial == NULL)
                 r_info("Open failed.");
-        else 
+        else
                 r_info("Serial connection opened.");
 
-        return (serial == NULL);
+        return (_serial == NULL);
 }
 
 static void close_serial()
 {
-        mutex_lock(mutex);        
-        if (serial) delete_serial(serial);
-        serial = NULL;
-        initialized = 0;
-        mutex_unlock(mutex);        
+        mutex_lock(_mutex);
+        if (_serial) delete_serial(_serial);
+        _serial = NULL;
+        _initialized = 0;
+        mutex_unlock(_mutex);
 }
 
 static int send_command_unlocked(const char *cmd, membuf_t *message)
@@ -69,7 +76,7 @@ static int send_command_unlocked(const char *cmd, membuf_t *message)
         int err = 0;
         const char *r;
 
-        r = serial_command_send(serial, message, cmd);
+        r = serial_command_send(_serial, message, cmd);
         r_debug("%s -> %s", cmd, membuf_data(message));
 
         // ToDo: This code is used in multiple places. Refactor.
@@ -79,54 +86,54 @@ static int send_command_unlocked(const char *cmd, membuf_t *message)
         } else if (strncmp(r, "ERR", 3) == 0) {
             return -1;
         }
-        
+
         return err;
 }
 
 static int send_command(const char *cmd, membuf_t *message)
 {
         int err;
-        mutex_lock(mutex);        
+        mutex_lock(_mutex);
         err = send_command_unlocked(cmd, message);
-        mutex_unlock(mutex);
+        mutex_unlock(_mutex);
         return err;
 }
 
 static int reset_cnc()
 {
         r_debug("Resetting CNC");
-	
-	serial_println(serial, "");
-	serial_println(serial, "");
+
+	serial_println(_serial, "");
+	serial_println(_serial, "");
 	clock_sleep(2);
-        serial_flush(serial);
+        serial_flush(_serial);
 
         r_debug("Homing");
-        if (send_command("$H", reply) != 0) {
+        if (send_command("$H", _reply) != 0) {
                 r_err("Homing failed");
                 return -1;
         }
 
         r_debug("Making sure spindle is off");
-        if (send_command("M5", reply) != 0) {
+        if (send_command("M5", _reply) != 0) {
                 r_err("Spindle off failed");
                 return -1;
         }
 
         r_debug("Setting origin");
-        if (send_command("g92 x0 y0 z0", reply) != 0) {
+        if (send_command("g92 x0 y0 z0", _reply) != 0) {
                 r_err("g91 failed");
                 return -1;
         }
 
         r_debug("Setting absolute positioning");
-        if (send_command("g90", reply) != 0) {
+        if (send_command("g90", _reply) != 0) {
                 r_err("g90 failed");
                 return -1;
         }
 
         r_debug("Set units to millimeters");
-        if (send_command("g21", reply) != 0) {
+        if (send_command("g21", _reply) != 0) {
                 r_err("g21 failed");
                 return -1;
         }
@@ -137,61 +144,136 @@ static int reset_cnc()
 static int set_device(const char *dev)
 {
         close_serial();
-        if (device != NULL) {
-                r_free(device);
-                device = NULL;
+        if (_device != NULL) {
+                r_free(_device);
+                _device = NULL;
         }
-        device = r_strdup(dev);
-        if (device == NULL) {
+        _device = r_strdup(dev);
+        if (_device == NULL) {
                 r_err("Out of memory");
                 return -1;
         }
         return 0;
 }
 
+static int get_device(json_object_t config)
+{
+        int err;
+        if (_device == NULL) {
+                // If device != NULL, it was given on the command
+                // line. The command line has priority over the
+                // configuration file.
+
+                const char *device = json_object_getstr(config, "device");
+                if (device == NULL) {
+                        r_err("Missing value 'grbl.device' in configuration");
+                        err = -1;
+                } else {
+                        err = set_device(device);
+                }
+        }
+        return err;
+}
+
+static int get_range_ij(json_object_t a, int i, int j)
+{
+        int err = 0;
+        double v = json_array_getnum(a, j);
+        if (isnan(v)) {
+                r_err("Value [%i,%j] in range is invalid", i, j);
+                err = -1;
+        } else {
+                _range[i][j] = v;
+        }
+        return err;
+}
+
+static int get_range_i_loop(json_object_t a, int i)
+{
+        for (int j = 0; j < 2; j++)
+                if (get_range_ij(a, i, j) != 0)
+                        return -1;
+        return 0;
+}
+
+static int get_range_i(json_object_t r, int i)
+{
+        int err;
+        json_object_t a = json_array_get(r, i);
+        if (!json_isarray(a)) {
+                r_err("Range of dimension %d is not an array", i);
+                err = -1;
+        } else {
+                err = get_range_i_loop(a, i);
+        }
+        return err;
+}
+
+static int get_range_loop(json_object_t r)
+{
+        for (int i = 0; i < 3; i++)
+                if (get_range_i(r, i) != 0)
+                        return -1;
+        return 0;
+}
+
+static int get_range(json_object_t config)
+{
+        int err;
+        json_object_t r = json_object_get(config, "range");
+        if (!json_isarray(r)) {
+                r_err("Invalid range in configuration");
+                err = -1;
+        } else {
+                err = get_range_loop(r);
+                r_info("range set to: x[%.3f,%.3f], y[%.3f,%.3f], z[%.3f,%.3f]",
+                       _range[XAXIS][MIN], _range[XAXIS][MAX],
+                       _range[YAXIS][MIN], _range[YAXIS][MAX],
+                       _range[ZAXIS][MIN], _range[ZAXIS][MAX]);
+        }
+        return err;
+}
+
 static int get_configuration()
 {
-        if (device != NULL)
-                return 0;
-        
-        json_object_t dev = client_get("configuration", "grbl/device");
-        if (!json_isstring(dev)) {
-                r_err("the value of 'grbl.device' is not a string");
-                json_unref(dev);
-                return -1;
-        }
-        
-        int err = set_device(json_string_value(dev));
-        json_unref(dev);
-        
+        int err;
+        json_object_t config = client_get("configuration", "grbl");
+
+        err = get_device(config);
+
+        if (err == 0)
+                err = get_range(config);
+
+        json_unref(config);
+
         return err;
 }
 
 static int cnc_init()
 {
-        if (initialized)
+        if (_initialized)
                 return 0;
-        
+
         if (get_configuration() != 0)
                 return -1;
-        
-        if (open_serial(device) != 0)
+
+        if (open_serial(_device) != 0)
                 return -1;
-        
+
         if (reset_cnc() != 0)
                 return -1;
-        
-        initialized = 1;
+
+        _initialized = 1;
         return 0;
 }
 
 int grbl_init(int argc, char **argv)
 {
         r_log_set_writer(broadcast_log, NULL);
-        
-        mutex = new_mutex();
-        reply = new_membuf();
-        if (mutex == NULL || reply == NULL)
+
+        _mutex = new_mutex();
+        _reply = new_membuf();
+        if (_mutex == NULL || _reply == NULL)
                 return -1;
 
         if (argc >= 2) {
@@ -208,30 +290,28 @@ int grbl_init(int argc, char **argv)
                 clock_sleep(0.2);
         }
 
-        r_err("failed to initialize the cnc");        
+        r_err("failed to initialize the cnc");
         return -1;
 }
 
 void grbl_cleanup()
 {
         close_serial();
-        if (mutex)
-                delete_mutex(mutex);
-        if (reply)
-                delete_membuf(reply);
+        delete_mutex(_mutex);
+        delete_membuf(_reply);
 }
 
 static int grbl_idle()
 {
         int ret = -1;
         const char *r;
-        
+
         r_debug("CNC: put '?'");
-        serial_lock(serial);
-        serial_put(serial, '?');
-        r = serial_readline(serial, reply);
-        serial_unlock(serial);
-        
+        serial_lock(_serial);
+        serial_put(_serial, '?');
+        r = serial_readline(_serial, _reply);
+        serial_unlock(_serial);
+
         if (r) r_debug("CNC status: '%s'", r);
         else r_debug("CNC status: NULL!");
 
@@ -253,11 +333,11 @@ static int grbl_idle()
 static void wait_cnc()
 {
         double start_time = clock_time();
-        
-        serial_lock(serial);
-        serial_flush(serial);
-        serial_unlock(serial);
-        
+
+        serial_lock(_serial);
+        serial_flush(_serial);
+        serial_unlock(_serial);
+
         while (grbl_idle() != 1 && clock_time() - start_time < 600.0) {
                 r_debug("Waiting for CNC to finish");
                 clock_sleep(1);
@@ -280,7 +360,7 @@ int cnc_onmoveto(void *userdata,
         int hasy = json_object_has(command, "y");
         int hasz = json_object_has(command, "z");
         double x = 0.0, y = 0.0, z = 0.0;
-        
+
         if (!hasx && !hasy && !hasz) {
                 membuf_printf(message, "No coordinates given");
                 return -1;
@@ -292,16 +372,19 @@ int cnc_onmoveto(void *userdata,
                 membuf_printf(message, "Invalid coordinates");
                 return -1;
         }
-        if (hasx && (x < 0 || x > 2.0)) {
-                membuf_printf(message, "X value out of range [0,2]: %f", x);
+        if (hasx && (x < _range[XAXIS][MIN] || x > _range[XAXIS][MAX])) {
+                membuf_printf(message, "X value out of range [%.3f,%.3f]: %f",
+                              _range[XAXIS][MIN], _range[XAXIS][MAX], x);
                 return -1;
         }
-        if (hasy && (y < 0 || y > 2.0)) {
-                membuf_printf(message, "Y value out of range [0,2]: %f", y);
+        if (hasy && (y < _range[YAXIS][MIN] || y > _range[YAXIS][MAX])) {
+                membuf_printf(message, "Y value out of range [%.3f,%.3f]: %f",
+                              _range[YAXIS][MIN], _range[YAXIS][MAX], y);
                 return -1;
         }
-        if (hasz && (z > 0 || z < -2.0)) {
-                membuf_printf(message, "Z value out of range [-2,0]: %f", z);
+        if (hasz && (z < _range[ZAXIS][MIN] || z > _range[ZAXIS][MAX])) {
+                membuf_printf(message, "Z value out of range [%.3f,%.3f]: %f",
+                              _range[ZAXIS][MIN], _range[ZAXIS][MAX], z);
                 return -1;
         }
 
@@ -313,16 +396,67 @@ int cnc_onmoveto(void *userdata,
         if (hasz) membuf_printf(buf, " z%d", (int) (z * 1000.0));
         membuf_append_zero(buf);
 
-        mutex_lock(mutex);        
-        
+        mutex_lock(_mutex);
+
         int err = send_command_unlocked(membuf_data(buf), message);
         if (err == 0)
                 wait_cnc();
-        
-        mutex_unlock(mutex);        
+
+        mutex_unlock(_mutex);
         delete_membuf(buf);
 
         return err;
+}
+
+static int path_is_valid_point(json_object_t path, int i, membuf_t *message)
+{
+        json_object_t p = json_array_get(path, i);
+        if (!json_isarray(p) || json_array_length(p) < 3) {
+                membuf_printf(message, "Point %d is not valid", i);
+                return 0;
+        }
+
+        for (int j = 0; j < 3; j++) {
+                json_object_t n = json_array_get(p, j);
+                if (!json_isnumber(n)) {
+                        membuf_printf(message, "Coordinate (%d,%d) is not valid", i, j);
+                        return 0;
+                }
+                double v = json_number_value(n);
+                if (v < _range[j][MIN] || v > _range[j][MAX]) {
+                        membuf_printf(message,
+                                      "Coordinate (%d,%d) is out of range [%.3f, %.3f]: %.3f",
+                                      i, j, _range[j][MIN], _range[j][MAX], v);
+                        return 0;
+                }
+        }
+        return 1;
+}
+
+static int path_is_valid(json_object_t path, membuf_t *message)
+{
+        if (!json_isarray(path)) {
+                membuf_printf(message, "Expected an array for the path");
+                return 0;
+        }
+
+        if (json_array_length(path) == 0) {
+                membuf_printf(message, "Zero-length path");
+                return 0;
+        }
+
+        if (0) { // Debug
+                char buffer[2048];
+                json_tostring(path, buffer, sizeof(buffer));
+                r_debug("path: %s", buffer);
+        }
+
+        for (int i = 0; i < json_array_length(path); i++) {
+                if (!path_is_valid_point(path, i, message))
+                        return 0;
+        }
+
+        return 1;
 }
 
 int cnc_ontravel(void *userdata,
@@ -331,63 +465,26 @@ int cnc_ontravel(void *userdata,
                  membuf_t *message)
 {
 	r_debug("cnc_ontravel");
-        
+
         if (cnc_init() != 0) {
                 membuf_printf(message, "CNC not initialized");
                 return 0;
         }
-        
-        json_object_t path = json_object_get(command, "path");
-        if (!json_isarray(path)) {
-                membuf_printf(message, "Expected an array for the path");
-                return -1;
-        }
 
-        char buffer[2048];
-        json_tostring(path, buffer, sizeof(buffer));
-        r_debug("path: %s", buffer);
-        
-        // Check the path
-        for (int i = 0; i < json_array_length(path); i++) {
-                json_object_t p = json_array_get(path, i);
-                if (!json_isarray(p) || json_array_length(p) < 3) {
-                        membuf_printf(message, "Point %d is not a valid", i);
-                        return -1;
-                }
-                for (int j = 0; j < 3; j++) {
-                        json_object_t v;
-                        v = json_array_get(p, j);
-                        if (!json_isnumber(v)) {
-                                membuf_printf(message, "Coordinate (%d,%d) is not a valid", i, j);
-                                return -1;
-                        }
-                        // TODO: check against CNC dimensions
-                }
-        }
+        json_object_t path = json_object_get(command, "path");
+        if (!path_is_valid(path, message))
+                return -1;
 
         int err = 0;
         membuf_t *buf = new_membuf();
-        
-        mutex_lock(mutex);        
-        
+
+        mutex_lock(_mutex);
+
         for (int i = 0; i < json_array_length(path); i++) {
                 json_object_t p = json_array_get(path, i);
                 double x = json_array_getnum(p, 0);
                 double y = json_array_getnum(p, 1);
                 double z = json_array_getnum(p, 2);
-                if (x < 0 || x > 2.0) {
-                        membuf_printf(message, "X value out of range [0,2]: %f", x);
-                        break;
-                }
-                if (y < 0 || y > 2.0) {
-                        membuf_printf(message, "Y value out of range [0,2]: %f", y);
-                        break;
-                }
-                if (z > 0 || z < -2.0) {
-                        membuf_printf(message, "Z value out of range [-2,0]: %f", z);
-                        break;
-                }
-
                 r_debug("point %d: %d %d %d", i, (int) (x * 1000.0), (int) (y * 1000.0), (int) (z * 1000.0));
                 membuf_clear(buf);
                 membuf_printf(buf, "g0 x%d y%d z%d", (int) (x * 1000.0), (int) (y * 1000.0), (int) (z * 1000.0));
@@ -399,8 +496,8 @@ int cnc_ontravel(void *userdata,
 
         if (err == 0)
                 wait_cnc();
-        
-        mutex_unlock(mutex);        
+
+        mutex_unlock(_mutex);
         delete_membuf(buf);
 
         return err;
@@ -417,7 +514,7 @@ int cnc_onspindle(void *userdata,
                 membuf_printf(message, "CNC not initialized");
                 return 0;
         }
-        
+
         double speed = json_object_getnum(command, "speed");
         if (isnan(speed) || speed < 0.0 || speed > 1.0) {
                 membuf_printf(message, "Invalid speed");

--- a/romi-rover/grbl/grbl.c
+++ b/romi-rover/grbl/grbl.c
@@ -181,10 +181,12 @@ static int get_range(json_object_t config)
                 err = -1;
         } else {
                 err = cnc_range_parse(&_range, r);
-                r_info("range set to: x[%.3f,%.3f], y[%.3f,%.3f], z[%.3f,%.3f]",
-                       _range.x[0], _range.x[1],
-                       _range.y[0], _range.y[1],
-                       _range.z[0], _range.z[1]);
+                if (err == 0) {
+                        r_info("range set to: x[%.3f,%.3f], y[%.3f,%.3f], z[%.3f,%.3f]",
+                               _range.x[0], _range.x[1],
+                               _range.y[0], _range.y[1],
+                               _range.z[0], _range.z[1]);
+                } // else: error message alreay printed by cnc_range_parse()
         }
         return err;
 }

--- a/romi-rover/grbl/grbl.c
+++ b/romi-rover/grbl/grbl.c
@@ -56,7 +56,7 @@ static int open_serial(const char *dev)
         else
                 r_info("Serial connection opened.");
 
-        return (_serial == NULL);
+        return (_serial == NULL)? -1 : 0;
 }
 
 static void close_serial()


### PR DESCRIPTION
Added a range (min and pax positions) to test valid moveto and travel commands. This avoids possible out-of-range positions and allows better testing. 
The static variables have been prefixed with an underscore to avoid confusion with local variables. 