### PR TITLE
improved out-of-range handling; reduced memory leaks

### DIFF
--- a/romi-rover/fake_cnc/CMakeLists.txt
+++ b/romi-rover/fake_cnc/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_cnc fake_cnc.c fake_cnc_main.c)
-target_link_libraries(fake_cnc rcom r)
+target_link_libraries(fake_cnc rcom romi r)
 install(TARGETS fake_cnc DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fake_cnc/fake_cnc.c
+++ b/romi-rover/fake_cnc/fake_cnc.c
@@ -21,12 +21,19 @@
   <http://www.gnu.org/licenses/>.
 
  */
+#include <r.h>
+#include <romi.h>
 #include "fake_cnc.h"
 
-static mutex_t *mutex = NULL;
+static int _initialized = 0;
+static char *_device = NULL;
+static mutex_t *_mutex = NULL;
+
 static double _x = 0.0;
 static double _y = 0.0;
 static double _z = 0.0;
+
+static cnc_range_t _range = {{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}};
 
 static void broadcast_log(void *userdata, const char* s)
 {
@@ -36,16 +43,186 @@ static void broadcast_log(void *userdata, const char* s)
                 messagelink_send_str(log, s);
 }
 
+////////////////////////////////////////////
+
+static int open_serial(const char *dev)
+{
+        r_debug("Open serial %s", dev);
+        return 0;
+}
+
+static void close_serial()
+{
+        r_debug("Close serial");
+}
+
+//////////////////////////////////////////////
+
+static int set_spindle_speed(double speed, membuf_t *message)
+{
+        return 0;
+}
+
+static int do_homing(membuf_t *message)
+{
+        return 0;
+}
+
+static int reset_cnc()
+{
+        _x = 0.0;
+        _y = 0.0;
+        _z = 0.0;
+        return 0;
+}
+
+static void wait_cnc()
+{
+        // Nothing to do
+}
+
+static int moveto(int hasx, int hasy, int hasz,
+                  double x, double y, double z,
+                  membuf_t *message)
+{
+        if (hasx)
+                _x = x;
+        if (hasy)
+                _y = y;
+        if (hasz)
+                _z = z;
+	r_debug("position[%.4f,%.4f,%.4f]", _x, _y, _z);
+        return 0;
+}
+
+//////////////////////////////////////////////
+
+static int set_device(const char *dev)
+{
+        close_serial();
+        if (_device != NULL) {
+                r_free(_device);
+                _device = NULL;
+        }
+        _device = r_strdup(dev);
+        return 0;
+}
+
+static int get_device()
+{
+        return 0;
+}
+
+static int get_range()
+{
+        int err = 0;
+        
+        json_object_t config = client_get("configuration", "cnc");
+        if (json_isobject(config)) {
+                
+                json_object_t r = json_object_get(config, "range");
+                if (!json_isarray(r)) {
+                        r_err("Invalid range in configuration");
+                        err = -1;
+                } else {
+                        err = cnc_range_parse(&_range, r);
+                        if (err == 0) {
+                                r_info("range set to: x[%.3f,%.3f], y[%.3f,%.3f], z[%.3f,%.3f]",
+                                       _range.x[0], _range.x[1],
+                                       _range.y[0], _range.y[1],
+                                       _range.z[0], _range.z[1]);
+                        } // else: error message alreay printed by cnc_range_parse()
+                }
+        } else {
+                r_err("Couldn't find CNC configuration");
+                err = -1;
+        }
+        json_unref(config);
+        return err;
+}
+
+static int get_configuration()
+{
+        int err;
+
+        err = get_device();
+
+        if (err == 0)
+                err = get_range();
+
+
+        return err;
+}
+
+static int try_cnc_init()
+{
+        if (_initialized)
+                return 0;
+
+        if (get_configuration() != 0)
+                return -1;
+        
+        if (open_serial(_device) != 0)
+                return -1;
+
+        if (reset_cnc() != 0) {
+                close_serial();
+                return -1;
+        }
+
+        _initialized = 1;
+        return 0;
+}
+
+static int cnc_init()
+{
+        int r = -1;
+        for (int i = 0; i < 10; i++) {
+                if (try_cnc_init() == 0) {
+                        r = 0;
+                        break;
+                }
+                r_err("cnc_init failed: attempt %d/10", i);
+                clock_sleep(0.5);
+        }
+        return r;
+}
+
 int fake_cnc_init(int argc, char **argv)
 {
+        int r = 0;
+        
         r_log_set_writer(broadcast_log, NULL);
-        mutex = new_mutex();
-        return 0;
+        
+        _mutex = new_mutex();
+
+        if (argc >= 2) {
+                r_debug("using serial device given on command line: '%s'", argv[1]);
+                if (set_device(argv[1]) != 0)
+                        r = -1;
+        }
+
+        if (r == 0)
+                r = cnc_init();
+        
+        return r;
 }
 
 void fake_cnc_cleanup()
 {
-        delete_mutex(mutex);
+        close_serial();
+        delete_mutex(_mutex);
+}
+
+static int cnc_move(int hasx, int hasy, int hasz,
+                    double x, double y, double z,
+                    membuf_t *message)
+{
+        int r;
+        mutex_lock(_mutex); 
+        r = moveto(hasx, hasy, hasz, x, y, z, message);
+        mutex_unlock(_mutex);
+        return r;
 }
 
 int cnc_onmoveto(void *userdata,
@@ -53,34 +230,105 @@ int cnc_onmoveto(void *userdata,
                  json_object_t command,
                  membuf_t *message)
 {
-	r_debug("cnc_onmoveto");
+	r_debug("handle_moveto");
 
-//        const char *r;
+        if (cnc_init() != 0) {
+                membuf_printf(message, "CNC not initialized");
+                return 0;
+        }
+
         int hasx = json_object_has(command, "x");
         int hasy = json_object_has(command, "y");
         int hasz = json_object_has(command, "z");
         double x = 0.0, y = 0.0, z = 0.0;
-        
+
         if (!hasx && !hasy && !hasz) {
                 membuf_printf(message, "No coordinates given");
                 return -1;
         }
-        if (hasx) x = json_object_getnum(command, "x");
-        if (hasy) y = json_object_getnum(command, "y");
-        if (hasz) z = json_object_getnum(command, "z");
+        if (hasx)
+                x = json_object_getnum(command, "x");
+        if (hasy)
+                y = json_object_getnum(command, "y");
+        if (hasz)
+                z = json_object_getnum(command, "z");
+        
         if (isnan(x) || isnan(y) || isnan(z)) {
                 membuf_printf(message, "Invalid coordinates");
                 return -1;
         }
+        if (hasx && (x < _range.x[0] || x > _range.x[1])) {
+                membuf_printf(message, "X value out of range [%.3f,%.3f]: %f",
+                              _range.x[0], _range.x[1], x);
+                return -1;
+        }
+        if (hasy && (y < _range.y[0] || y > _range.y[1])) {
+                membuf_printf(message, "Y value out of range [%.3f,%.3f]: %f",
+                              _range.y[0], _range.y[1], y);
+                return -1;
+        }
+        if (hasz && (z < _range.z[0] || z > _range.z[1])) {
+                membuf_printf(message, "Z value out of range [%.3f,%.3f]: %f",
+                              _range.z[0], _range.z[1], z);
+                return -1;
+        }
 
-        mutex_lock(mutex);        
-        if (hasx) _x = x;
-        if (hasy) _y = y;
-        if (hasz) _z = z;
-	r_debug("position[%.4f,%.4f,%.4f]", _x, _y, _z);
-        mutex_unlock(mutex);
+        int err = cnc_move(hasx, hasy, hasz, x, y, z, message);
+        if (err == 0)
+                wait_cnc();
+
+        return err;
+}
+
+static int path_is_valid_point(json_object_t path, int i, membuf_t *message)
+{
+        json_object_t p = json_array_get(path, i);
+        if (!json_isarray(p) || json_array_length(p) < 3) {
+                membuf_printf(message, "Point %d is not valid", i);
+                return 0;
+        }
+
+        double v[3];
+        for (int j = 0; j < 3; j++) {
+                json_object_t n = json_array_get(p, j);
+                if (!json_isnumber(n)) {
+                        membuf_printf(message, "Coordinate (%d,%d) is not valid", i, j);
+                        return 0;
+                }
+                v[j] = json_number_value(n);
+        }
         
-        return 0;
+        int valid = cnc_range_is_valid(&_range, v[0], v[1], v[2]);
+        if (!valid)
+                membuf_printf(message, "Point %d is out of range: (%.3f, %.3f, %.3f)",
+                              i, v[0], v[1], v[2]);
+        return valid;
+}
+
+static int path_is_valid(json_object_t path, membuf_t *message)
+{
+        if (!json_isarray(path)) {
+                membuf_printf(message, "Expected an array for the path");
+                return 0;
+        }
+
+        if (json_array_length(path) == 0) {
+                membuf_printf(message, "Zero-length path");
+                return 0;
+        }
+
+        if (0) { // Debug
+                char buffer[2048];
+                json_tostring(path, buffer, sizeof(buffer));
+                r_debug("path: %s", buffer);
+        }
+
+        for (int i = 0; i < json_array_length(path); i++) {
+                if (!path_is_valid_point(path, i, message))
+                        return 0;
+        }
+
+        return 1;
 }
 
 int cnc_ontravel(void *userdata,
@@ -89,46 +337,38 @@ int cnc_ontravel(void *userdata,
                  membuf_t *message)
 {
 	r_debug("cnc_ontravel");
-        
+
+        if (cnc_init() != 0) {
+                membuf_printf(message, "CNC not initialized");
+                return 0;
+        }
+
         json_object_t path = json_object_get(command, "path");
-        if (!json_isarray(path)) {
-                membuf_printf(message, "Expected an array for the path");
+        if (!path_is_valid(path, message))
                 return -1;
-        }
-
-        // Check the path
-        for (int i = 0; i < json_array_length(path); i++) {
-                json_object_t p = json_array_get(path, i);
-                if (!json_isarray(p) || json_array_length(p) < 3) {
-                        membuf_printf(message, "Point %d is not a valid", i);
-                        return -1;
-                }
-                for (int j = 0; j < 3; j++) {
-                        json_object_t v;
-                        v = json_array_get(p, j);
-                        if (!json_isnumber(v)) {
-                                membuf_printf(message, 
-                                              "Coordinate (%d,%d) is not a valid", i, j);
-                                return -1;
-                        }
-                        // TODO: check against CNC dimensions
-                }
-        }
-
-        mutex_lock(mutex);        
+        
+        int err = 0;
+        
+        mutex_lock(_mutex);        
         
         for (int i = 0; i < json_array_length(path); i++) {
                 json_object_t p = json_array_get(path, i);
-                _x = json_array_getnum(p, 0);
-                _y = json_array_getnum(p, 1);
-                _z = json_array_getnum(p, 2);
-                r_debug("position[%.4f,%.4f,%.4f]", _x, _y, _z);
-                clock_sleep(0.2);
+                double x = json_array_getnum(p, 0);
+                double y = json_array_getnum(p, 1);
+                double z = json_array_getnum(p, 2);
+                r_debug("point %d: %d %d %d", i, (int) (x * 1000.0), (int) (y * 1000.0), (int) (z * 1000.0));
+                err = moveto(1, 1, 1, x, y, z, message);
+                if (err)
+                        break;
+                clock_sleep(0.5);
         }
         
-        mutex_unlock(mutex);        
+        mutex_unlock(_mutex);        
 
-        return 0;
+        if (err == 0)
+                wait_cnc();
+
+        return err;
 }
 
 int cnc_onspindle(void *userdata,
@@ -136,8 +376,20 @@ int cnc_onspindle(void *userdata,
                   json_object_t command,
                   membuf_t *message)
 {
-	r_debug("cnc_onspindle");
-        return 0;
+	r_debug("Spindle event");
+
+        if (cnc_init() != 0) {
+                membuf_printf(message, "CNC not initialized");
+                return 0;
+        }
+
+        double speed = json_object_getnum(command, "speed");
+        if (isnan(speed) || speed < 0.0 || speed > 1.0) {
+                membuf_printf(message, "Invalid speed");
+                return -1;
+        }
+
+        return set_spindle_speed(speed, message);
 }
 
 int cnc_onhoming(void *userdata,
@@ -145,6 +397,11 @@ int cnc_onhoming(void *userdata,
                  json_object_t command,
                  membuf_t *message)
 {
-	r_debug("cnc_onhoming");
-        return 0;
+	r_debug("Homing");
+
+        if (cnc_init() != 0) {
+                membuf_printf(message, "CNC not initialized");
+                return 0;
+        }
+        return do_homing(message);
 }

--- a/romi-rover/weeder/quincunx.c
+++ b/romi-rover/weeder/quincunx.c
@@ -111,8 +111,6 @@ static void store_svg(fileset_t *fileset,
                 return;
         
         membuf_t *buffer = new_membuf();
-        if (buffer == NULL)
-                return;
         
         membuf_printf(buffer,
                       ("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"
@@ -130,6 +128,7 @@ static void store_svg(fileset_t *fileset,
         membuf_printf(buffer, "</svg>\n");
 
         file_import_svg(file, membuf_data(buffer), membuf_len(buffer));
+        delete_membuf(buffer);
 }
 
 static void store_quincunx_metadata(fileset_t *fileset, quincunx_module_t *module, double duration)
@@ -297,11 +296,14 @@ static image_t *compute_convolution(fileset_t *fileset, image_t *image, int w, f
                 corr_avg /= (corr->width * corr->height);
                 *avg = corr_avg;
 
-                image_t *im = image_clone(corr);
-                int len = im->width * im->height;
-                for (int i = 0; i < len; i++)
-                        im->data[i] /= corr_max;
-                store_png(fileset, "position-probability-map", im);
+                {
+                        image_t *im = image_clone(corr);
+                        int len = im->width * im->height;
+                        for (int i = 0; i < len; i++)
+                                im->data[i] /= corr_max;
+                        store_png(fileset, "position-probability-map", im);
+                        delete_image(im);
+                }
         } else {
                 corr = image_clone(image);
         }

--- a/romi-rover/weeder/weeder.c
+++ b/romi-rover/weeder/weeder.c
@@ -43,6 +43,7 @@ static char *directory = NULL;
 static database_t *db = NULL;
 static scan_t *scan = NULL;
 static pipeline_t *pipeline = NULL;
+static cnc_range_t _range = {{0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}};
 
 
 messagelink_t *get_messagelink_cnc();
@@ -121,6 +122,34 @@ static int init_workspace()
         
         json_unref(config);
         return 0;
+}
+
+static int get_range()
+{
+        int err = 0;
+        
+        json_object_t config = client_get("configuration", "cnc");
+        if (json_isobject(config)) {
+                
+                json_object_t r = json_object_get(config, "range");
+                if (!json_isarray(r)) {
+                        r_err("Invalid range in configuration");
+                        err = -1;
+                } else {
+                        err = cnc_range_parse(&_range, r);
+                        if (err == 0) {
+                                r_info("range set to: x[%.3f,%.3f], y[%.3f,%.3f], z[%.3f,%.3f]",
+                                       _range.x[0], _range.x[1],
+                                       _range.y[0], _range.y[1],
+                                       _range.z[0], _range.z[1]);
+                        } // else: error message alreay printed by cnc_range_parse()
+                }
+        } else {
+                r_err("Couldn't find CNC configuration");
+                err = -1;
+        }
+        json_unref(config);
+        return err;
 }
 
 static void broadcast_db_message(void *userdata,
@@ -231,7 +260,9 @@ static int init()
         if (initialized)
                 return 0;
         if (init_workspace() != 0)
-                return -1;        
+                return -1;
+        if (get_range() != 0)
+                return -1;
         if (init_pipeline() != 0)
                 return -1;        
         initialized = 1;
@@ -276,7 +307,7 @@ void weeder_onmessage_cnc(void *userdata,
 
 static int move_away_arm()
 {
-        json_object_t reply;
+        json_object_t reply = json_null();
         messagelink_t *cnc = get_messagelink_cnc();
         membuf_t *message = new_membuf();
         
@@ -285,8 +316,11 @@ static int move_away_arm()
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
                 delete_membuf(message);
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
+        
         // move weeding tool to the end of the workspace
         reply = messagelink_send_command_f(cnc, "{\"command\": \"moveto\", "
                                            "\"x\": 0, \"y\": %.4f}",
@@ -294,23 +328,50 @@ static int move_away_arm()
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
                 delete_membuf(message);
+                json_unref(reply);
                 return -1;
         }
         delete_membuf(message);
+        json_unref(reply);
         return 0;
+}
+
+static void return_to_base()
+{
+        messagelink_t *cnc = get_messagelink_cnc();
+        json_object_t reply = json_null();
+        membuf_t *message = new_membuf();
+                
+        // stop the spindle
+        reply = messagelink_send_command_f(cnc, "{\"command\": \"spindle\", \"speed\": 0}");
+        if (status_error(reply, message)) {
+                r_err("spindle returned error: %s", membuf_data(message));
+        }
+        json_unref(reply);
+        
+        // home
+        reply = messagelink_send_command_f(cnc, "{\"command\": \"homing\"}");
+        if (status_error(reply, message)) {
+                r_err("homing returned error: %s", membuf_data(message));
+        }
+        
+        json_unref(reply);
+        delete_membuf(message);
 }
 
 static int send_path(list_t *path, double z0, membuf_t *message)
 {
         messagelink_t *cnc = get_messagelink_cnc();
-        json_object_t reply;
+        json_object_t reply = json_null();
 
         // move weeding tool up
         reply = messagelink_send_command_f(cnc, "{\"command\": \"moveto\", \"z\": 0}");
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
 
         // move to the first point on the path
         point_t *p = list_get(path, point_t);
@@ -320,36 +381,73 @@ static int send_path(list_t *path, double z0, membuf_t *message)
                                            p->x, p->y);
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
 
         // start the spindle
         reply = messagelink_send_command_f(cnc, "{\"command\": \"spindle\", \"speed\": 1}");
         if (status_error(reply, message)) {
                 r_err("spindle returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
 
         // move weeding tool down
         reply = messagelink_send_command_f(cnc, "{\"command\": \"moveto\", \"z\": %.4f}",
                                            z0);
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
 
         // convert path to json
         membuf_t *buf = new_membuf();
         membuf_printf(buf, "{\"command\": \"travel\", \"path\": [");
         for (list_t *l = path; l != NULL; l = list_next(l)) {
                 point_t *p = list_get(l, point_t);
-                membuf_printf(buf, "[%.4f,%.4f,%.4f]", p->x, p->y, z0);
-                if (list_next(l)) membuf_printf(buf, ",");
+                double x = p->x;
+                double y = p->y;
+                double z = z0;
+                
+                if (!cnc_range_is_valid(&_range, x, y, z)) {
+                        if (cnc_range_error(&_range, x, y, z) < 0.01) {
+                                // Small error: clip
+                                // TODO: call cnc_range to do this
+                                if (x < _range.x[0])
+                                        x = _range.x[0];
+                                if (x > _range.x[1])
+                                        x = _range.x[1];
+                                if (y < _range.y[0])
+                                        y = _range.y[0];
+                                if (y > _range.y[1])
+                                        y = _range.y[1];
+                                if (z < _range.z[0])
+                                        z = _range.z[0];
+                                if (z > _range.z[1])
+                                        z = _range.z[1];
+                        } else {
+                                r_err("Computed point out of range: %.3f, %.3f, %.3f", x, y, z);
+                                delete_membuf(buf);
+                                return -1;
+                        }
+                }
+                
+                membuf_printf(buf, "[%.4f,%.4f,%.4f]", x, y, z);
+                if (list_next(l))
+                        membuf_printf(buf, ",");
         }
         membuf_printf(buf, "]}");
         membuf_append_zero(buf);
 
-        r_debug("path: %s", membuf_data(buf));
+        /* r_debug("path 1"); */
+        /* r_debug("path: %s", membuf_data(buf)); */
+        /* printf("%s\n", membuf_data(buf)); */
+        /* r_debug("path 2"); */
         
         // send path to cnc
         messagelink_send_text(cnc, membuf_data(buf), membuf_len(buf));
@@ -358,23 +456,29 @@ static int send_path(list_t *path, double z0, membuf_t *message)
         if (status_error(reply, message)) {
                 r_err("travel returned error: %s", membuf_data(message));
                 delete_membuf(buf);
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
         delete_membuf(buf);
 
         // move weeding tool up
         reply = messagelink_send_command_f(cnc, "{\"command\": \"moveto\", \"z\": 0}");
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
 
         // stop spindle
         reply = messagelink_send_command_f(cnc, "{\"command\": \"spindle\", \"speed\": 0}");
         if (status_error(reply, message)) {
                 r_err("spindle returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
+        json_unref(reply);
 
         // move to the top-left corner
         reply = messagelink_send_command_f(cnc,
@@ -383,9 +487,11 @@ static int send_path(list_t *path, double z0, membuf_t *message)
                                            workspace.height_meter);
         if (status_error(reply, message)) {
                 r_err("moveto returned error: %s", membuf_data(message));
+                json_unref(reply);
                 return -1;
         }
 
+        json_unref(reply);
         return 0;
 }
 
@@ -472,15 +578,17 @@ static int hoe(int method, json_object_t command, membuf_t *message)
         // Execute the path
         if (json_object_has(command, "skip-execution")) {
                 r_info("Skipping execution of path)");
+                err = 0;
         } else {
                 err = send_path(path, z0, message);
         }
         
         r_info("Finished executing path");
 
-        err = 0;
-        
 cleanup:
+        if (err != 0)
+                return_to_base();
+        
         for (list_t *l = path; l != NULL; l = list_next(l)) {
                 point_t *p = list_get(l, point_t);
                 delete_point(p);


### PR DESCRIPTION
- when the weeder sent a point that was out-of-range for the CNC, the weeder and the CNC remained in a bad state. These changes improve the situation. 
- fake_cnc has changed a lot: it's remodeled after the grbl implementation. This improves testing.
- there were many memory leaks in weeder.c. Most have been fixed.
