### PR TITLE
rcom testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if (BUILD_COVERAGE AND BUILD_TESTS)
         # lcov doesn't build with CMake so we download, set lcov as an external target, then call make.
         # we then manually add the bin path so that we can call it later.
         download_project(   PROJ              lcov
-                URL               https://github.com/linux-test-project/lcov/releases/download/v1.14/lcov-1.14.tar.gz
+                URL               https://github.com/linux-test-project/lcov/releases/download/v1.15/lcov-1.15.tar.gz
                 PREFIX            ${CMAKE_DOWNLOAD_DIRECTORY}/lcov
                 TIMEOUT           180
                 ${UPDATE_DISCONNECTED_IF_AVAILABLE}

--- a/romi-rover/CMakeLists.txt
+++ b/romi-rover/CMakeLists.txt
@@ -29,6 +29,11 @@ set(CMAKE_C_FLAGS_DEBUG "-O0")
 
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${PROJECT_SANITISE_FLAGS}")
 
+# Can't build for coverage without the test.
+if (BUILD_COVERAGE AND BUILD_TESTS)
+  append_coverage_compiler_flags()
+endif()
+
 ############################################################
 
 option(WITH_REALSENSE "Compile the realsense app" OFF)

--- a/romi-rover/brush_motors/CMakeLists.txt
+++ b/romi-rover/brush_motors/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(brush_motors brush_motors.c brush_motors_main.c)
-target_link_libraries(brush_motors romi rcomlib r m)
+target_link_libraries(brush_motors romi librcom r m)
 #install(TARGETS brush_motors DESTINATION bin/romi)
 
 if(BUILD_TESTS)

--- a/romi-rover/brush_motors/CMakeLists.txt
+++ b/romi-rover/brush_motors/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(brush_motors brush_motors.c brush_motors_main.c)
-target_link_libraries(brush_motors romi rcom r m)
+target_link_libraries(brush_motors romi rcomlib r m)
 #install(TARGETS brush_motors DESTINATION bin/romi)
 
 if(BUILD_TESTS)

--- a/romi-rover/brush_motors/test/CMakeLists.txt
+++ b/romi-rover/brush_motors/test/CMakeLists.txt
@@ -7,21 +7,21 @@ set(SRCS_PARSER
   ../BrushMotorController/Parser.cpp
   ../BrushMotorController/Parser.h)
 
-add_executable(r_unit_tests_parser ${SRCS_PARSER})
+add_executable(romi_rover_unit_tests_parser ${SRCS_PARSER})
 
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/../BrushMotorController" )
 
-target_link_libraries(r_unit_tests_parser gtest gmock)
+target_link_libraries(romi_rover_unit_tests_parser gtest gmock)
 
 add_test(
-    NAME r_unit_tests_parser
-    COMMAND r_unit_tests_parser
+    NAME romi_rover_unit_tests_parser
+    COMMAND romi_rover_unit_tests_parser
 )
 
 if(BUILD_COVERAGE)
     SETUP_TARGET_FOR_COVERAGE_LCOV(
-            NAME r_unit_tests_parser_coverage
+            NAME romi_rover_unit_tests_parser_coverage
             EXECUTABLE ctest -V ${n_cores}
-            DEPENDENCIES r_unit_tests_parser)
+            DEPENDENCIES romi_rover_unit_tests_parser)
 endif()
 

--- a/romi-rover/camera_recorder/CMakeLists.txt
+++ b/romi-rover/camera_recorder/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(camera_recorder camera_recorder.c camera_recorder_main.c)
-target_link_libraries(camera_recorder rcomlib romi r)
+target_link_libraries(camera_recorder librcom romi r)
 install(TARGETS camera_recorder DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/camera_recorder/CMakeLists.txt
+++ b/romi-rover/camera_recorder/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(camera_recorder camera_recorder.c camera_recorder_main.c)
-target_link_libraries(camera_recorder rcom romi r)
+target_link_libraries(camera_recorder rcomlib romi r)
 install(TARGETS camera_recorder DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/configuration/CMakeLists.txt
+++ b/romi-rover/configuration/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(configuration configuration.c configuration_main.c)
-target_link_libraries(configuration rcomlib r)
+target_link_libraries(configuration librcom r)
 install(TARGETS configuration DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/configuration/CMakeLists.txt
+++ b/romi-rover/configuration/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(configuration configuration.c configuration_main.c)
-target_link_libraries(configuration rcom r)
+target_link_libraries(configuration rcomlib r)
 install(TARGETS configuration DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/control_panel/CMakeLists.txt
+++ b/romi-rover/control_panel/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(control_panel control_panel.c control_panel_main.c)
-target_link_libraries(control_panel rcomlib r m)
+target_link_libraries(control_panel librcom r m)
 install(TARGETS control_panel DESTINATION bin/romi)
 
 if(BUILD_TESTS)

--- a/romi-rover/control_panel/CMakeLists.txt
+++ b/romi-rover/control_panel/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(control_panel control_panel.c control_panel_main.c)
-target_link_libraries(control_panel rcom r m)
+target_link_libraries(control_panel rcomlib r m)
 install(TARGETS control_panel DESTINATION bin/romi)
 
 if(BUILD_TESTS)

--- a/romi-rover/control_panel/test/CMakeLists.txt
+++ b/romi-rover/control_panel/test/CMakeLists.txt
@@ -104,8 +104,14 @@ add_test(
 
 if(BUILD_COVERAGE)
     SETUP_TARGET_FOR_COVERAGE_LCOV(
-            NAME romi_rover_unit_tests_statemachine_coverage
+            NAME romi_rover_unit_tests_coverage
             EXECUTABLE ctest -V ${n_cores} -R "romi_rover"
-            DEPENDENCIES romi_rover_unit_tests_statemachine)
+            DEPENDENCIES
+                romi_rover_unit_tests_controlpanel_parser
+                romi_rover_unit_tests_controlpanel_buttonpanel
+                romi_rover_unit_tests_controlpanel_eventtimer
+                romi_rover_unit_tests_controlpanel_menu
+                romi_rover_unit_tests_controlpanel_statemachine
+                romi_rover_unit_tests_controlpanel_controlpanel)
 endif()
 

--- a/romi-rover/control_panel/test/CMakeLists.txt
+++ b/romi-rover/control_panel/test/CMakeLists.txt
@@ -56,56 +56,56 @@ set(SRCS_CONTROLPANEL
   ../ControlPanelLcdKeypad/ControlPanelTransitions.cpp
   )
 
-add_executable(r_unit_tests_controlpanel_parser ${SRCS_PARSER})
-add_executable(r_unit_tests_controlpanel_buttonpanel ${SRCS_BUTTONPANEL})
-add_executable(r_unit_tests_controlpanel_eventtimer ${SRCS_EVENTTIMER})
-add_executable(r_unit_tests_controlpanel_menu ${SRCS_MENU})
-add_executable(r_unit_tests_controlpanel_statemachine ${SRCS_STATE_MACHINE})
-add_executable(r_unit_tests_controlpanel_controlpanel ${SRCS_CONTROLPANEL})
+add_executable(romi_rover_unit_tests_controlpanel_parser ${SRCS_PARSER})
+add_executable(romi_rover_unit_tests_controlpanel_buttonpanel ${SRCS_BUTTONPANEL})
+add_executable(romi_rover_unit_tests_controlpanel_eventtimer ${SRCS_EVENTTIMER})
+add_executable(romi_rover_unit_tests_controlpanel_menu ${SRCS_MENU})
+add_executable(romi_rover_unit_tests_controlpanel_statemachine ${SRCS_STATE_MACHINE})
+add_executable(romi_rover_unit_tests_controlpanel_controlpanel ${SRCS_CONTROLPANEL})
 
 include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/../ControlPanelLcdKeypad" )
 
-target_link_libraries(r_unit_tests_controlpanel_parser gtest gmock)
-target_link_libraries(r_unit_tests_controlpanel_buttonpanel gtest gmock)
-target_link_libraries(r_unit_tests_controlpanel_eventtimer gtest gmock)
-target_link_libraries(r_unit_tests_controlpanel_menu gtest gmock)
-target_link_libraries(r_unit_tests_controlpanel_statemachine gtest gmock)
-target_link_libraries(r_unit_tests_controlpanel_controlpanel gtest gmock)
+target_link_libraries(romi_rover_unit_tests_controlpanel_parser gtest gmock)
+target_link_libraries(romi_rover_unit_tests_controlpanel_buttonpanel gtest gmock)
+target_link_libraries(romi_rover_unit_tests_controlpanel_eventtimer gtest gmock)
+target_link_libraries(romi_rover_unit_tests_controlpanel_menu gtest gmock)
+target_link_libraries(romi_rover_unit_tests_controlpanel_statemachine gtest gmock)
+target_link_libraries(romi_rover_unit_tests_controlpanel_controlpanel gtest gmock)
 
 add_test(
-    NAME r_unit_tests_controlpanel_parser
-    COMMAND r_unit_tests_controlpanel_parser
+    NAME romi_rover_unit_tests_controlpanel_parser
+    COMMAND romi_rover_unit_tests_controlpanel_parser
 )
 
 add_test(
-    NAME r_unit_tests_controlpanel_buttonpanel
-    COMMAND r_unit_tests_controlpanel_buttonpanel
+    NAME romi_rover_unit_tests_controlpanel_buttonpanel
+    COMMAND romi_rover_unit_tests_controlpanel_buttonpanel
 )
 
 add_test(
-    NAME r_unit_tests_controlpanel_eventtimer
-    COMMAND r_unit_tests_controlpanel_eventtimer
+    NAME romi_rover_unit_tests_controlpanel_eventtimer
+    COMMAND romi_rover_unit_tests_controlpanel_eventtimer
 )
 
 add_test(
-    NAME r_unit_tests_controlpanel_menu
-    COMMAND r_unit_tests_controlpanel_menu
+    NAME romi_rover_unit_tests_controlpanel_menu
+    COMMAND romi_rover_unit_tests_controlpanel_menu
 )
 
 add_test(
-    NAME r_unit_tests_controlpanel_statemachine
-    COMMAND r_unit_tests_controlpanel_statemachine
+    NAME romi_rover_unit_tests_controlpanel_statemachine
+    COMMAND romi_rover_unit_tests_controlpanel_statemachine
 )
 
 add_test(
-    NAME r_unit_tests_controlpanel_controlpanel
-    COMMAND r_unit_tests_controlpanel_controlpanel
+    NAME romi_rover_unit_tests_controlpanel_controlpanel
+    COMMAND romi_rover_unit_tests_controlpanel_controlpanel
 )
 
 if(BUILD_COVERAGE)
     SETUP_TARGET_FOR_COVERAGE_LCOV(
-            NAME r_unit_tests_statemachine_coverage
-            EXECUTABLE ctest -V ${n_cores}
-            DEPENDENCIES r_unit_tests_statemachine)
+            NAME romi_rover_unit_tests_statemachine_coverage
+            EXECUTABLE ctest -V ${n_cores} -R "romi_rover"
+            DEPENDENCIES romi_rover_unit_tests_statemachine)
 endif()
 

--- a/romi-rover/fake_camera/CMakeLists.txt
+++ b/romi-rover/fake_camera/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_camera fake_camera.c fake_camera_main.c)
-target_link_libraries(fake_camera rcomlib r)
+target_link_libraries(fake_camera librcom r)
 install(TARGETS fake_camera DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fake_camera/CMakeLists.txt
+++ b/romi-rover/fake_camera/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_camera fake_camera.c fake_camera_main.c)
-target_link_libraries(fake_camera rcom r)
+target_link_libraries(fake_camera rcomlib r)
 install(TARGETS fake_camera DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fake_cnc/CMakeLists.txt
+++ b/romi-rover/fake_cnc/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_cnc fake_cnc.c fake_cnc_main.c)
-target_link_libraries(fake_cnc rcomlib romi r)
+target_link_libraries(fake_cnc librcom romi r)
 install(TARGETS fake_cnc DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fake_cnc/CMakeLists.txt
+++ b/romi-rover/fake_cnc/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_cnc fake_cnc.c fake_cnc_main.c)
-target_link_libraries(fake_cnc rcom romi r)
+target_link_libraries(fake_cnc rcomlib romi r)
 install(TARGETS fake_cnc DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fake_motors/CMakeLists.txt
+++ b/romi-rover/fake_motors/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_motors fake_motors.c fake_motors_main.c)
-target_link_libraries(fake_motors rcomlib r m)
+target_link_libraries(fake_motors librcom r m)
 install(TARGETS fake_motors DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fake_motors/CMakeLists.txt
+++ b/romi-rover/fake_motors/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fake_motors fake_motors.c fake_motors_main.c)
-target_link_libraries(fake_motors rcom r m)
+target_link_libraries(fake_motors rcomlib r m)
 install(TARGETS fake_motors DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fsdb/CMakeLists.txt
+++ b/romi-rover/fsdb/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fsdb fsdb_node.c fsdb_main.c)
-target_link_libraries(fsdb rcomlib romi r)
+target_link_libraries(fsdb librcom romi r)
 install(TARGETS fsdb DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/fsdb/CMakeLists.txt
+++ b/romi-rover/fsdb/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(fsdb fsdb_node.c fsdb_main.c)
-target_link_libraries(fsdb rcom romi r)
+target_link_libraries(fsdb rcomlib romi r)
 install(TARGETS fsdb DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/gimbal_bldc/CMakeLists.txt
+++ b/romi-rover/gimbal_bldc/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(gimbal_bldc gimbal_bldc.c gimbal_bldc_main.c)
-target_link_libraries(gimbal_bldc romi rcomlib r m)
+target_link_libraries(gimbal_bldc romi librcom r m)
 #install(TARGETS gimbal_bldc DESTINATION bin/romi)
 
 #if(BUILD_TESTS)

--- a/romi-rover/gimbal_bldc/CMakeLists.txt
+++ b/romi-rover/gimbal_bldc/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(gimbal_bldc gimbal_bldc.c gimbal_bldc_main.c)
-target_link_libraries(gimbal_bldc romi rcom r m)
+target_link_libraries(gimbal_bldc romi rcomlib r m)
 #install(TARGETS gimbal_bldc DESTINATION bin/romi)
 
 #if(BUILD_TESTS)

--- a/romi-rover/gimbal_servo/CMakeLists.txt
+++ b/romi-rover/gimbal_servo/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(gimbal_servo gimbal_servo.c gimbal_servo_main.c)
-target_link_libraries(gimbal_servo romi rcomlib r m)
+target_link_libraries(gimbal_servo romi librcom r m)
 install(TARGETS gimbal_servo DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/gimbal_servo/CMakeLists.txt
+++ b/romi-rover/gimbal_servo/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(gimbal_servo gimbal_servo.c gimbal_servo_main.c)
-target_link_libraries(gimbal_servo romi rcom r m)
+target_link_libraries(gimbal_servo romi rcomlib r m)
 install(TARGETS gimbal_servo DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/grbl/CMakeLists.txt
+++ b/romi-rover/grbl/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(grbl grbl.c grbl_main.c)
-target_link_libraries(grbl rcomlib romi r)
+target_link_libraries(grbl librcom romi r)
 install(TARGETS grbl DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/grbl/CMakeLists.txt
+++ b/romi-rover/grbl/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(grbl grbl.c grbl_main.c)
-target_link_libraries(grbl rcom romi r)
+target_link_libraries(grbl rcomlib romi r)
 install(TARGETS grbl DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/navigation/CMakeLists.txt
+++ b/romi-rover/navigation/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(navigation navigation.c navigation_main.c)
-target_link_libraries(navigation romi rcom r)
+target_link_libraries(navigation romi rcomlib r)
 install(TARGETS navigation DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/navigation/CMakeLists.txt
+++ b/romi-rover/navigation/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(navigation navigation.c navigation_main.c)
-target_link_libraries(navigation romi rcomlib r)
+target_link_libraries(navigation romi librcom r)
 install(TARGETS navigation DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/oquam/CMakeLists.txt
+++ b/romi-rover/oquam/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(liboquam SHARED ${SOURCES})
 target_link_libraries(liboquam r m)
 
 add_executable(oquam oquam.cpp oquam.hpp oquam_main.c)
-target_link_libraries(oquam liboquam rcom)
+target_link_libraries(oquam liboquam rcomlib)
 target_include_directories(oquam PRIVATE "${CMAKE_CURRENT_LIST_DIR}/src")
 install(TARGETS oquam DESTINATION bin/romi)
 

--- a/romi-rover/oquam/CMakeLists.txt
+++ b/romi-rover/oquam/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(liboquam SHARED ${SOURCES})
 target_link_libraries(liboquam r m)
 
 add_executable(oquam oquam.cpp oquam.hpp oquam_main.c)
-target_link_libraries(oquam liboquam rcomlib)
+target_link_libraries(oquam liboquam librcom)
 target_include_directories(oquam PRIVATE "${CMAKE_CURRENT_LIST_DIR}/src")
 install(TARGETS oquam DESTINATION bin/romi)
 

--- a/romi-rover/picamera/CMakeLists.txt
+++ b/romi-rover/picamera/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(picamera picamera.cc picamera_main.c)
-target_link_libraries(picamera rcomlib romi r raspicam)
+target_link_libraries(picamera librcom romi r raspicam)
 install(TARGETS picamera DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/picamera/CMakeLists.txt
+++ b/romi-rover/picamera/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(picamera picamera.cc picamera_main.c)
-target_link_libraries(picamera rcom romi r raspicam)
+target_link_libraries(picamera rcomlib romi r raspicam)
 install(TARGETS picamera DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/rclogger/CMakeLists.txt
+++ b/romi-rover/rclogger/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(rclogger rclogger.c rclogger_main.c)
-target_link_libraries(rclogger rcomlib romi r)
+target_link_libraries(rclogger librcom romi r)
 install(TARGETS rclogger DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/rclogger/CMakeLists.txt
+++ b/romi-rover/rclogger/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(rclogger rclogger.c rclogger_main.c)
-target_link_libraries(rclogger rcom romi r)
+target_link_libraries(rclogger rcomlib romi r)
 install(TARGETS rclogger DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/realsense/CMakeLists.txt
+++ b/romi-rover/realsense/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(realsense realsense.cc realsense_main.c convert.c)
-target_link_libraries(realsense rcom romi r jpeg png realsense2)
+target_link_libraries(realsense rcomlib romi r jpeg png realsense2)
 install(TARGETS realsense DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/realsense/CMakeLists.txt
+++ b/romi-rover/realsense/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(realsense realsense.cc realsense_main.c convert.c)
-target_link_libraries(realsense rcomlib romi r jpeg png realsense2)
+target_link_libraries(realsense librcom romi r jpeg png realsense2)
 install(TARGETS realsense DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/script_engine/CMakeLists.txt
+++ b/romi-rover/script_engine/CMakeLists.txt
@@ -11,5 +11,5 @@ ADD_CUSTOM_COMMAND(
   )
 
 add_executable(script_engine script_engine.c script_engine_main.c)
-target_link_libraries(script_engine romi rcom r)
+target_link_libraries(script_engine romi rcomlib r)
 install(TARGETS script_engine DESTINATION bin/romi)

--- a/romi-rover/script_engine/CMakeLists.txt
+++ b/romi-rover/script_engine/CMakeLists.txt
@@ -11,5 +11,5 @@ ADD_CUSTOM_COMMAND(
   )
 
 add_executable(script_engine script_engine.c script_engine_main.c)
-target_link_libraries(script_engine romi rcomlib r)
+target_link_libraries(script_engine romi librcom r)
 install(TARGETS script_engine DESTINATION bin/romi)

--- a/romi-rover/script_engine/script_engine.c
+++ b/romi-rover/script_engine/script_engine.c
@@ -143,7 +143,7 @@ static int move(membuf_t *message, double distance, double speed)
         return status_error("navigation", reply, message);
 }
 
-int32 _iterator(const char* key, json_object_t value, json_object_t request)
+int32_t _iterator(const char* key, json_object_t value, json_object_t request)
 {
         if (rstreq(key, "action"))
                 return 0;

--- a/romi-rover/video4linux/CMakeLists.txt
+++ b/romi-rover/video4linux/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(video4linux video4linux.c video4linux_main.c camera_v4l.c)
-target_link_libraries(video4linux romi rcom r jpeg)
+target_link_libraries(video4linux romi rcomlib r jpeg)
 install(TARGETS video4linux DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/video4linux/CMakeLists.txt
+++ b/romi-rover/video4linux/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(video4linux video4linux.c video4linux_main.c camera_v4l.c)
-target_link_libraries(video4linux romi rcomlib r jpeg)
+target_link_libraries(video4linux romi librcom r jpeg)
 install(TARGETS video4linux DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/watchdog/CMakeLists.txt
+++ b/romi-rover/watchdog/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(watchdog watchdog.c watchdog_main.c)
-target_link_libraries(watchdog rcomlib r m)
+target_link_libraries(watchdog librcom r m)
 install(TARGETS watchdog DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/watchdog/CMakeLists.txt
+++ b/romi-rover/watchdog/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(watchdog watchdog.c watchdog_main.c)
-target_link_libraries(watchdog rcom r m)
+target_link_libraries(watchdog rcomlib r m)
 install(TARGETS watchdog DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/webproxy/CMakeLists.txt
+++ b/romi-rover/webproxy/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(webproxy webproxy.c webproxy_main.c)
-target_link_libraries(webproxy rcomlib r m)
+target_link_libraries(webproxy librcom r m)
 install(TARGETS webproxy DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/webproxy/CMakeLists.txt
+++ b/romi-rover/webproxy/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(webproxy webproxy.c webproxy_main.c)
-target_link_libraries(webproxy rcom r m)
+target_link_libraries(webproxy rcomlib r m)
 install(TARGETS webproxy DESTINATION bin/romi)
 
 ADD_CUSTOM_COMMAND(

--- a/romi-rover/weeder/CMakeLists.txt
+++ b/romi-rover/weeder/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(weeder weeder.c weeder_main.c weeding.c svm.c otsu.c quincunx.c profiling.c workspace.c point.c)
-target_link_libraries(weeder rcomlib romi r m)
+target_link_libraries(weeder librcom romi r m)
 
 add_executable(weeder_compute weeder_compute.c weeding.c svm.c otsu.c quincunx.c profiling.c workspace.c point.c)
 target_link_libraries(weeder_compute romi r m)

--- a/romi-rover/weeder/CMakeLists.txt
+++ b/romi-rover/weeder/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(weeder weeder.c weeder_main.c weeding.c svm.c otsu.c quincunx.c profiling.c workspace.c point.c)
-target_link_libraries(weeder rcom romi r m)
+target_link_libraries(weeder rcomlib romi r m)
 
 add_executable(weeder_compute weeder_compute.c weeding.c svm.c otsu.c quincunx.c profiling.c workspace.c point.c)
 target_link_libraries(weeder_compute romi r m)

--- a/romi-rover/weeder/weeder.c
+++ b/romi-rover/weeder/weeder.c
@@ -519,7 +519,7 @@ static int send_path(list_t *path, double z0, membuf_t *message)
         return 0;
 }
 
-static int32 _set_param(const char* key, json_object_t value, void* data)
+static int32_t _set_param(const char* key, json_object_t value, void* data)
 {
         membuf_t *message = (membuf_t *) data;
         

--- a/romi-rover/wheel_odometry/CMakeLists.txt
+++ b/romi-rover/wheel_odometry/CMakeLists.txt
@@ -11,5 +11,5 @@ ADD_CUSTOM_COMMAND(
   )
 
 add_executable(wheel_odometry wheel_odometry.c wheel_odometry_main.c)
-target_link_libraries(wheel_odometry rcomlib romi r m)
+target_link_libraries(wheel_odometry librcom romi r m)
 install(TARGETS wheel_odometry DESTINATION bin/romi)

--- a/romi-rover/wheel_odometry/CMakeLists.txt
+++ b/romi-rover/wheel_odometry/CMakeLists.txt
@@ -11,5 +11,5 @@ ADD_CUSTOM_COMMAND(
   )
 
 add_executable(wheel_odometry wheel_odometry.c wheel_odometry_main.c)
-target_link_libraries(wheel_odometry rcom romi r m)
+target_link_libraries(wheel_odometry rcomlib romi r m)
 install(TARGETS wheel_odometry DESTINATION bin/romi)


### PR DESCRIPTION
Changes related to build system.
gcc9 changes
use of mocks library in libr
use of renamed rcom library (librcom)
build path changes.